### PR TITLE
Issue45 server

### DIFF
--- a/server/mysite/question/admin.py
+++ b/server/mysite/question/admin.py
@@ -8,3 +8,12 @@ class QuestionAdmin(admin.ModelAdmin):
     date_hierarchy='posted_at'
 
 admin.site.register(Question,QuestionAdmin)
+
+def dummytest():
+    """
+    >>> 1==1
+    True
+    """
+def _test():
+    import doctest
+    doctest.testmod()

--- a/server/mysite/question/tests.py
+++ b/server/mysite/question/tests.py
@@ -152,7 +152,13 @@ def test_about_csrf():
     pass
 
 from django.test import TestCase
+import unittest
+import doctest
+import mysite.question.twutil.tw_util as tw_util
 
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocTestSuite(tw_util))
+    return tests
 
 class SimpleTest(TestCase):
     def test_basic_addition(self):

--- a/server/mysite/question/tests.py
+++ b/server/mysite/question/tests.py
@@ -48,12 +48,10 @@ def test_about_get_view():
     >>> import json
     >>> c=Client(enforce_csrf_checks=True)
     >>> response=c.get('/api/get/')
-    >>> response.status_code
-    200
-    >>> jsonobj=json.loads(response.content)
-    >>> 'status' in jsonobj
+    >>> jobj=json.loads(response.content)
+    >>> jobj['status']=='OK'
     True
-    >>> 'posts' in jsonobj
+    >>> jobj['posts']==[]
     True
     """    
     pass
@@ -65,20 +63,23 @@ def test_about_post():
     >>>
     >>> clean_questions()
     >>> from django.test.client import Client
+    >>> import json
     >>> 
     >>> c=Client(enforce_csrf_checks=True)
     >>> 
     >>> # getは認証の必要がありません
     >>> response=c.get('/api/get/')
-    >>> response.content
-    '{"status": "OK", "posts": []}'
-    >>> 
+    >>> jobj=json.loads(response.content)
+    >>> jobj['status']=='OK'
+    True
+    >>> jobj['posts']==[]
+    True
     >>> 
     >>> # postはログインしていないとできません（403 Forbidden）
     >>> response=c.post('/api/post/',dict(title='before login',body='cannot post'))
-    >>> response.content
-    '{"status": "Forbidden"}'
-    >>> 
+    >>> jobj=json.loads(response.content)
+    >>> jobj['status']=='Forbidden'
+    True
     >>> 
     >>> # authでユーザーを新規作成しています。
     >>> # access_token=accの場合、
@@ -87,15 +88,18 @@ def test_about_post():
     >>> # すでに同じusernameのユーザーがいた場合、
     >>> # createdはfalseになります
     >>> response=c.get('/api/auth/?access_token=acc3')
-    >>> response.content
-    '{"status": "OK", "created": true}'
+    >>> jobj=json.loads(response.content)
+    >>> jobj['status']=='OK'
+    True
+    >>> jobj['created']
+    True
     >>> 
     >>> 
     >>> # authをしただけでは、まだpostできません
     >>> response=c.post('/api/post/',dict(title='before login',body='cannot post'))
-    >>> response.content
-    '{"status": "Forbidden"}'
-    >>> 
+    >>> jobj=json.loads(response.content)
+    >>> jobj['status']=='Forbidden'
+    True
     >>> 
     >>> # ログインはusernameとpasswordを指定して行います。
     >>> # 戻り値がTrueならログイン成功です。
@@ -104,21 +108,25 @@ def test_about_post():
     >>> 
     >>> # ログインして始めてpostできます
     >>> response=c.post('/api/post/',dict(title='after login',body='can post'))
-    >>> response.content
-    '{"status": "OK"}'
-    >>> 
+    >>> jobj=json.loads(response.content)
+    >>> jobj['status']=='OK'
+    True
     >>> 
     >>> # getで確かめてみると、確かに投稿が反映されています。
     >>> response=c.get('/api/get/')
-    >>> response.content
-    '{"status": "OK", "posts": [{"body": "can post", "title": "after login"}]}'
+    >>> jobj=json.loads(response.content)
+    >>> jobj['status']=='OK'
+    True
+    >>> jobj['posts']==[dict(title='after login', body='can post')]
+    True
     >>> 
     >>>
     >>> # ログアウトしてpostできなくなることを確認します
     >>> c.logout()
     >>> response=c.post('/api/post/',dict(title='after logout',body='cannot post'))
-    >>> response.content
-    '{"status": "Forbidden"}'
+    >>> jobj=json.loads(response.content)
+    >>> jobj['status']=='Forbidden'
+    True
     """
     pass
 
@@ -126,13 +134,16 @@ def test_about_csrf():
     """
     >>> clean_questions()
     >>> from django.test.client import Client
+    >>> import json
+    >>> 
     >>> c1=Client()
     >>> response=c1.get('/api/auth/?access_token=acc')
     >>> c1.login(username='acc_name',password='acc')
     True
     >>> response=c1.post('/api/post/',dict(title='csrf test2',body='this pass'))
-    >>> response.status_code
-    200
+    >>> jobj=json.loads(response.content)
+    >>> jobj['status']=='OK'
+    True
     >>> 
     >>> 
     >>> c2=Client(enforce_csrf_checks=True)
@@ -140,8 +151,9 @@ def test_about_csrf():
     >>> c2.login(username='acc2_name',password='acc2')
     True
     >>> response=c2.post('/api/post/',dict(title='csrf test2',body='this pass'))
-    >>> response.status_code
-    200
+    >>> jobj=json.loads(response.content)
+    >>> jobj['status']=='OK'
+    True
     """
 
     # もしviews.pyのpost_viewに@csrf_exemptデコレーターをつけないと、

--- a/server/mysite/question/tests.py
+++ b/server/mysite/question/tests.py
@@ -5,7 +5,40 @@ def clean_questions():
     from mysite.question.models import Question
     Question.objects.all().delete()
 
+def clean_users():
+    """ before test, call this method for clear users """
+    from django.contrib.auth.models import User
+    User.objects.exclude(pk=1).delete()
+
 def test_about_auth_view():
+    """
+    >>> clean_users()
+    >>> from django.test.client import Client    
+    >>> from mysite.question.twutil.consumer_info import spa_key, spa_secret
+    >>> import json
+    >>> c=Client(enforce_csrf_checks=True)
+    >>> url='/api/auth/?access_token_key=%s&access_token_secret=%s' % (spa_key, spa_secret)
+    >>> response=c.get(url)
+    >>> jobj=json.loads(response.content)
+    >>> jobj['status']=='OK'
+    True
+    >>> jobj['created']
+    True
+    >>> 
+    >>> response=c.get(url)
+    >>> jobj=json.loads(response.content)
+    >>> jobj['status']=='OK'
+    True
+    >>> jobj['created']
+    False
+    >>> 
+    >>> url='/api/auth/?access_token_key=%s&access_token_secret=%s' % ('dummy key', 'dummy secret')
+    >>> response=c.get(url)
+    >>> jobj=json.loads(response.content)
+    >>> jobj['status']=='Not Found'
+    True
+    """
+
     """
     >>> clean_questions()
     >>> from django.test.client import Client

--- a/server/mysite/question/tests.py
+++ b/server/mysite/question/tests.py
@@ -39,18 +39,6 @@ def test_about_auth_view():
     True
     """
 
-    """
-    >>> clean_questions()
-    >>> from django.test.client import Client
-    >>> import json
-    >>> c=Client(enforce_csrf_checks=True)
-    >>> response=c.get('/api/auth/?access_token=acc')
-    >>> response.status_code
-    200
-    >>> jsonobj=json.loads(response.content)
-    >>> 'status' in jsonobj
-    True
-    """
     pass
 
 def test_about_get_view():

--- a/server/mysite/question/tests.py
+++ b/server/mysite/question/tests.py
@@ -155,9 +155,13 @@ from django.test import TestCase
 import unittest
 import doctest
 import mysite.question.twutil.tw_util as tw_util
+import mysite.question.views as views
+import mysite.question.admin as admin
 
 def load_tests(loader, tests, ignore):
     tests.addTests(doctest.DocTestSuite(tw_util))
+    tests.addTests(doctest.DocTestSuite(views))
+    tests.addTests(doctest.DocTestSuite(admin))
     return tests
 
 class SimpleTest(TestCase):

--- a/server/mysite/question/twutil/.gitignore
+++ b/server/mysite/question/twutil/.gitignore
@@ -1,0 +1,2 @@
+consumer_info.py
+get_token.py

--- a/server/mysite/question/twutil/tw_util.py
+++ b/server/mysite/question/twutil/tw_util.py
@@ -1,0 +1,37 @@
+# -*- coding:utf-8 -*-
+
+import tweepy
+import consumer_info
+
+def make_auth():
+    return tweepy.OAuthHandler(consumer_info.key,consumer_info.secret)
+    
+def make_api(user_key,user_secret):
+    auth=make_auth()
+    auth.set_access_token(user_key,user_secret)
+    api=tweepy.API(auth_handler=auth)
+    return api
+
+def get_vc(user_key,user_secret):
+    """
+    >>> import consumer_info as ci
+    >>> get_vc(ci.spa_key,ci.spa_secret)
+    {'screen_name': 'android_spa', 'id': 580619600, 'name': 'android_spa'}
+    >>> get_vc('dummy key','dummy secret')
+    {}
+    """
+    api=make_api(user_key,user_secret)
+    vc=api.verify_credentials()
+    if vc is False:
+        # 正しいアクセストークンキー、シークレットでなかった場合
+        return {}
+    ret=dict(id=vc.id, screen_name=vc.screen_name, name=vc.name)
+    return ret
+
+
+def _test():
+    import doctest
+    doctest.testmod()
+
+if __name__ == "__main__":
+    _test()

--- a/server/mysite/question/twutil/tw_util.py
+++ b/server/mysite/question/twutil/tw_util.py
@@ -15,10 +15,16 @@ def make_api(user_key,user_secret):
 def get_vc(user_key,user_secret):
     """
     >>> import consumer_info as ci
-    >>> get_vc(ci.spa_key,ci.spa_secret)
-    {'screen_name': 'android_spa', 'id': 580619600, 'name': 'android_spa'}
-    >>> get_vc('dummy key','dummy secret')
-    {}
+    >>> vc=get_vc(ci.spa_key,ci.spa_secret)
+    >>> vc['id']==580619600
+    True
+    >>> vc['screen_name']==u'android_spa'
+    True
+    >>> vc['name']==u'android_spa'
+    True
+    >>> vc=get_vc('dummy key','dummy secret')
+    >>> vc=={}
+    True
     """
     api=make_api(user_key,user_secret)
     vc=api.verify_credentials()

--- a/server/mysite/question/views.py
+++ b/server/mysite/question/views.py
@@ -26,13 +26,33 @@ def json_response_forbidden(context={}):
     return HttpResponseForbidden(convert_context_to_json(context),mimetype='application/json')
 
 def auth_view(request):
-    access_token=request.GET['access_token']
-    user_name=access_token+'_name'
+    if 'access_token' in request.GET:
+        # old api version
+        secret=request.GET['access_token']
+        user_name=secret+'_name'
+        try:
+            user=User.objects.get(username=user_name)
+            created=False
+        except:
+            user=User.objects.create_user(user_name,'',secret)
+            created=True
+            
+        context=dict(created=created)
+        return json_response(context)
+
+    from twutil.tw_util import get_vc
+
+    key=request.GET['access_token_key']    
+    secret=request.GET['access_token_secret']
+    vc=get_vc(key,secret)
+    if vc=={}:
+        return json_response_not_found()
+    user_name=vc['id']
     try:
         user=User.objects.get(username=user_name)
         created=False
     except:
-        user=User.objects.create_user(user_name,'',access_token)
+        user=User.objects.create_user(user_name,'',secret)
         created=True
 
     context=dict(created=created)

--- a/server/mysite/question/views.py
+++ b/server/mysite/question/views.py
@@ -33,7 +33,7 @@ def auth_view(request):
         try:
             user=User.objects.get(username=user_name)
             created=False
-        except:
+        except User.DoesNotExist:
             user=User.objects.create_user(user_name,'',secret)
             created=True
             
@@ -51,7 +51,7 @@ def auth_view(request):
     try:
         user=User.objects.get(username=user_name)
         created=False
-    except:
+    except User.DoesNotExist:
         user=User.objects.create_user(user_name,'',secret)
         created=True
 

--- a/server/mysite/question/views.py
+++ b/server/mysite/question/views.py
@@ -75,3 +75,7 @@ def post_view(request):
         return json_response()
     else:
         return json_response_forbidden()
+
+def _test():
+    import doctest
+    doctest.testmod()


### PR DESCRIPTION
#45 に関する実装

やったこと
Tweepyを使ってAccessToken(Key,Secret)からid,screen_name,nameの取得（tw_util.pyのget_vcで実装）
これにより/api/auth/にaccess_tokne_key,access_token_secretの2つを渡すように変更が必要です。
（現在はaccess_tokenしか渡されていないソースコードも適切に処理してます）

ここらへんはapiの仕様の変更なので、すこし議論＋周知が必要です

テストとして、/api/authに正しいアクセストークン（android_spaの）でGETしたときと、間違ったトークン（dummy key,dummy secret）でアクセスした時の挙動をテストしています。

間違ったトークンとしてつかえる形式が微妙です。
例：dummy_secretを使うとエラーなど
基本的にクライアント側で取得した適切なアクセストークンが来るので、例外処理はしてません
