### PR TITLE
Issue65

### DIFF
--- a/server/mysite/question/tests.py
+++ b/server/mysite/question/tests.py
@@ -47,6 +47,15 @@ def test_about_auth_view():
     >>> jobj=json.loads(response.content)
     >>> jobj['status']=='Not Found'
     True
+
+    # some dummy access token, cause server error
+    # catch exception and return server error
+    >>> url = url_template % ('spam', 'egg')
+    >>> c = Client(enforce_csrf_checks=True)
+    >>> response = c.get(url)
+    >>> jobj = json.loads(response.content)
+    >>> jobj['status'] == 'Server Error'
+    True
     """
 
     pass
@@ -186,6 +195,51 @@ def test_about_login():
     True
     """
     # ログインと認証が同時にできるようになりました
+
+
+def test_about_bad_request():
+    """
+    >>> from django.test.client import Client
+    >>> import json
+    >>> from question.twutil.consumer_info import spa_key, spa_secret
+
+    >>> c = Client(enforce_csrf_checks=True)
+
+    # this is bad request.
+    # because does not send access_token_key,access_token_secret
+    # so server return Bad Request
+    >>> url_template='/api/auth/?access_token=%s'
+    >>> url = url_template % 'ACC'
+    >>> response = c.get(url)
+    >>> jobj = json.loads(response.content)
+    >>> jobj['status'] == 'Bad Request'
+    True
+
+    # to test bad request of post, login
+    >>> url_template='/api/auth/?access_token_key=%s&access_token_secret=%s'
+    >>> url = url_template % (spa_key, spa_secret)
+    >>> response = c.get(url)
+
+    # this is bad request.
+    # because does not send body
+    # so server return Bad Request
+    >>> response =c.post('/api/post/',
+    ...                  dict(title='test none boddy'))
+    >>> jobj = json.loads(response.content)
+    >>> jobj['status'] == 'Bad Request'
+    True
+
+    # this is bad request.
+    # because does not send title
+    # so server return Bad Request
+    >>> response = c.post('/api/post/',
+    ...                   dict(body='test none title'))
+    >>> jobj = json.loads(response.content)
+    >>> jobj['status'] == 'Bad Request'
+    True
+    """
+    # Must send essential parameter
+    # if does't send, server return Bad Request
 
 
 from django.test import TestCase

--- a/server/mysite/question/tests.py
+++ b/server/mysite/question/tests.py
@@ -179,6 +179,7 @@ def test_about_login():
     >>> from django.test.client import Client
     >>> from mysite.question.twutil.consumer_info import spa_key, spa_secret
     >>> import json
+
     >>> c = Client(enforce_csrf_checks=True)
     >>> url_template = '/api/auth/?access_token_key=%s&access_token_secret=%s'
     >>> url = url_template % (spa_key, spa_secret)
@@ -186,6 +187,7 @@ def test_about_login():
     >>> j = json.loads(r.content)
     >>> j['status'] == 'OK'
     True
+
     >>> r = c.post('/api/post/', dict(title='test', body='hello world'))
     >>> r = c.get('/api/get/')
     >>> j = json.loads(r.content)
@@ -208,7 +210,7 @@ def test_about_bad_request():
     # this is bad request.
     # because does not send access_token_key,access_token_secret
     # so server return Bad Request
-    >>> url_template='/api/auth/?access_token=%s'
+    >>> url_template = '/api/auth/?access_token=%s'
     >>> url = url_template % 'ACC'
     >>> response = c.get(url)
     >>> jobj = json.loads(response.content)
@@ -216,15 +218,15 @@ def test_about_bad_request():
     True
 
     # to test bad request of post, login
-    >>> url_template='/api/auth/?access_token_key=%s&access_token_secret=%s'
+    >>> url_template = '/api/auth/?access_token_key=%s&access_token_secret=%s'
     >>> url = url_template % (spa_key, spa_secret)
     >>> response = c.get(url)
 
     # this is bad request.
     # because does not send body
     # so server return Bad Request
-    >>> response =c.post('/api/post/',
-    ...                  dict(title='test none boddy'))
+    >>> response = c.post('/api/post/',
+    ...                   dict(title='test none boddy'))
     >>> jobj = json.loads(response.content)
     >>> jobj['status'] == 'Bad Request'
     True

--- a/server/mysite/question/views.py
+++ b/server/mysite/question/views.py
@@ -38,20 +38,6 @@ def json_response_forbidden(context={}):
 
 
 def auth_view(request):
-    if 'access_token' in request.GET:
-        # old api version
-        secret = request.GET['access_token']
-        user_name = secret + '_name'
-        try:
-            User.objects.get(username=user_name)
-            created = False
-        except User.DoesNotExist:
-            User.objects.create_user(user_name, '', secret)
-            created = True
-
-        context = dict(created=created)
-        return json_response(context)
-
     from twutil.tw_util import get_vc
 
     key = request.GET['access_token_key']


### PR DESCRIPTION
#65 に関する変更　および、エラーの捕捉とそれに関するテストの記述

/api/auth/はaccess_token_key, access_token_secretが
/api/post/はtitle, bodyが渡されない場合はBad Requestとして処理

/api/auth/に渡されるアクセストークンKEY/SECRETは
正しいもの spa_key, spa_secret
正しくないが、エラーにならないもの 'dummy key', 'dummy secret'
正しくなく、かつTweepyの処理でエラーになるもの 'spam', 'egg'
の3つがある。それぞれについて
OK, Not Found, Server Errorを返すようにしエラーをきちんと補足するように修正。
