### PR TITLE
HQTPProxyでの例外処理(Issue62 client)

### DIFF
--- a/client/src/org/hqtp/android/HQTPAPIException.java
+++ b/client/src/org/hqtp/android/HQTPAPIException.java
@@ -1,0 +1,7 @@
+package org.hqtp.android;
+
+public class HQTPAPIException extends Exception {
+    public HQTPAPIException(String message){
+        super(message);
+    }
+}

--- a/client/src/org/hqtp/android/HQTPAPIException.java
+++ b/client/src/org/hqtp/android/HQTPAPIException.java
@@ -1,7 +1,9 @@
 package org.hqtp.android;
 
 public class HQTPAPIException extends Exception {
-    public HQTPAPIException(String message){
+    private static final long serialVersionUID = 943074838947651984L;
+
+    public HQTPAPIException(String message) {
         super(message);
     }
 }

--- a/client/src/org/hqtp/android/HQTPProxy.java
+++ b/client/src/org/hqtp/android/HQTPProxy.java
@@ -1,14 +1,18 @@
 package org.hqtp.android;
 
+import java.io.IOException;
 import java.util.List;
+
+import org.json.JSONException;
 
 public interface HQTPProxy {
 
     // Instance methods
-    public abstract boolean authenticate(String access_token_key, String access_token_secret);
+    public abstract boolean authenticate(String access_token_key, String access_token_secret) throws IOException,
+            JSONException;
 
-    public abstract boolean postQuestion(String title, String body);
+    public abstract boolean postQuestion(String title, String body) throws JSONException, IOException;
 
-    public abstract List<Question> getQuestions();
+    public abstract List<Question> getQuestions() throws JSONException, IOException;
 
 }

--- a/client/src/org/hqtp/android/HQTPProxy.java
+++ b/client/src/org/hqtp/android/HQTPProxy.java
@@ -8,11 +8,13 @@ import org.json.JSONException;
 public interface HQTPProxy {
 
     // Instance methods
+    // TODO: 認証の成否は例外によって知られるべき。何を戻り値にするか検討が必要。
     public abstract boolean authenticate(String access_token_key, String access_token_secret) throws IOException,
-            JSONException;
+            JSONException, HQTPAPIException;
 
-    public abstract boolean postQuestion(String title, String body) throws JSONException, IOException;
+    // TODO: 質問投稿の成否は例外によって知られるべき。戻り値としてはおそらく投稿IDが妥当と考えられる。
+    public abstract boolean postQuestion(String title, String body) throws JSONException, IOException, HQTPAPIException;
 
-    public abstract List<Question> getQuestions() throws JSONException, IOException;
+    public abstract List<Question> getQuestions() throws JSONException, IOException, HQTPAPIException;
 
 }

--- a/client/src/org/hqtp/android/HQTPProxyImpl.java
+++ b/client/src/org/hqtp/android/HQTPProxyImpl.java
@@ -54,7 +54,7 @@ public class HQTPProxyImpl implements HQTPProxy {
         params.put("access_token_secret", access_token_secret);
         HttpResponse response = sendByGet("auth/", params);
         JSONObject json = toJSON(response.getEntity());
-        if (json.getString("status") != "OK") {
+        if (!json.getString("status").equals("OK")) {
             throw new HQTPAPIException("Authentication failed. : /api/auth returned status='"
                     + json.getString("status") + "'");
         }
@@ -71,7 +71,7 @@ public class HQTPProxyImpl implements HQTPProxy {
         response = sendByPost("post/", params);
         JSONObject json = toJSON(response.getEntity());
         Log.d("info", json.toString());
-        if (json.getString("status") != "OK") {
+        if (!json.getString("status").equals("OK")) {
             throw new HQTPAPIException("Post question failed. : /api/post returned status='"
                     + json.getString("status") + "'");
         }
@@ -87,7 +87,7 @@ public class HQTPProxyImpl implements HQTPProxy {
         json = toJSON(response.getEntity());
         Log.d("info", json.toString());
 
-        if (json.getString("status") != "OK") {
+        if (!json.getString("status").equals("OK")) {
             throw new HQTPAPIException("Getting questions failed. : /api/get returned status='"
                     + json.getString("status") + "'");
         }

--- a/client/src/org/hqtp/android/HQTPProxyImpl.java
+++ b/client/src/org/hqtp/android/HQTPProxyImpl.java
@@ -46,41 +46,40 @@ public class HQTPProxyImpl implements HQTPProxy {
     }
 
     @Override
-    public boolean authenticate(String access_token_key, String access_token_secret) throws IOException, JSONException {
+    public boolean authenticate(String access_token_key, String access_token_secret) throws IOException, JSONException,
+            HQTPAPIException {
         HashMap<String, String> params = new HashMap<String, String>();
         params.put("access_token_key", access_token_key);
         params.put("access_token_secret", access_token_secret);
-        boolean res = false;
         HttpResponse response = sendByGet("auth/", params);
         JSONObject json = toJSON(response.getEntity());
-        if (json.getString("status") == "OK") {
-            // TODO: 例外を投げるべき?
-            res = true;
+        if (json.getString("status") != "OK") {
+            throw new HQTPAPIException("Authentication failed. : /api/auth returned status='"
+                    + json.getString("status") + "'");
         }
 
-        return res;
+        return true;
     }
 
     @Override
-    public boolean postQuestion(String title, String body) throws JSONException, IOException {
+    public boolean postQuestion(String title, String body) throws JSONException, IOException, HQTPAPIException {
         HttpResponse response;
         HashMap<String, String> params = new HashMap<String, String>();
         params.put("title", title);
         params.put("body", body);
-        boolean res = false;
         response = sendByPost("post/", params);
         JSONObject json = toJSON(response.getEntity());
         Log.d("info", json.toString());
-        if (json.getString("status") == "OK") {
-            // TODO: 例外を投げるべき?
-            res = true;
+        if (json.getString("status") != "OK") {
+            throw new HQTPAPIException("Post question failed. : /api/post returned status='"
+                    + json.getString("status") + "'");
         }
 
-        return res;
+        return true;
     }
 
     @Override
-    public List<Question> getQuestions() throws JSONException, IOException {
+    public List<Question> getQuestions() throws JSONException, IOException, HQTPAPIException {
         // ネットワークからの読込テスト
         JSONObject json;
         HttpResponse response = sendByGet("get/", null);
@@ -88,7 +87,8 @@ public class HQTPProxyImpl implements HQTPProxy {
         Log.d("info", json.toString());
 
         if (json.getString("status") != "OK") {
-            // TODO: エラー処理
+            throw new HQTPAPIException("Getting questions failed. : /api/get returned status='"
+                    + json.getString("status") + "'");
         }
         JSONArray array = json.getJSONArray("posts");
         ArrayList<Question> res = new ArrayList<Question>();

--- a/client/src/org/hqtp/android/HQTPProxyImpl.java
+++ b/client/src/org/hqtp/android/HQTPProxyImpl.java
@@ -46,78 +46,57 @@ public class HQTPProxyImpl implements HQTPProxy {
     }
 
     @Override
-    public boolean authenticate(String access_token_key, String access_token_secret) {
+    public boolean authenticate(String access_token_key, String access_token_secret) throws IOException, JSONException {
         HashMap<String, String> params = new HashMap<String, String>();
         params.put("access_token_key", access_token_key);
         params.put("access_token_secret", access_token_secret);
         boolean res = false;
-        try {
-            HttpResponse response = sendByGet("auth/", params);
-            JSONObject json = toJSON(response.getEntity());
-            if (json.getString("status") == "OK") {
-                res = true;
-            }
-        } catch (Exception e) {
-            // TODO: handle exception
-            e.printStackTrace();
+        HttpResponse response = sendByGet("auth/", params);
+        JSONObject json = toJSON(response.getEntity());
+        if (json.getString("status") == "OK") {
+            // TODO: 例外を投げるべき?
+            res = true;
         }
+
         return res;
     }
 
     @Override
-    public boolean postQuestion(String title, String body) {
+    public boolean postQuestion(String title, String body) throws JSONException, IOException {
         HttpResponse response;
-        HashMap<String , String> params = new HashMap<String, String>();
+        HashMap<String, String> params = new HashMap<String, String>();
         params.put("title", title);
         params.put("body", body);
         boolean res = false;
-        try{
-            response = sendByPost("post/", params);
-            JSONObject json = toJSON(response.getEntity());
-            Log.d("info", json.toString());
-            if(json.getString("status")=="OK"){
-                res = true;
-            }
-        }catch (Exception e) {
-            // TODO: handle exception
-            e.printStackTrace();
+        response = sendByPost("post/", params);
+        JSONObject json = toJSON(response.getEntity());
+        Log.d("info", json.toString());
+        if (json.getString("status") == "OK") {
+            // TODO: 例外を投げるべき?
+            res = true;
         }
+
         return res;
     }
 
     @Override
-    public List<Question> getQuestions() {
+    public List<Question> getQuestions() throws JSONException, IOException {
         // ネットワークからの読込テスト
         JSONObject json;
-        try {
-            HttpResponse response = sendByGet("get/",null);
-            //TODO: ネットワークまわりの例外とレスポンスまわりの例外処理がごっちゃになってるのをどうにかしたい
-            json = toJSON(response.getEntity());
-            Log.d("info", json.toString());
-        } catch (Exception e1) {
-            //TODO: 真面目に例外処理しましょう
-            Log.d("err", e1.getMessage());
-            e1.printStackTrace();
-            return null;
-        }
+        HttpResponse response = sendByGet("get/", null);
+        json = toJSON(response.getEntity());
+        Log.d("info", json.toString());
 
-        try{
-            if(json.getString("status")!="OK"){
-                //TODO: エラー処理
-            }
-            JSONArray array = json.getJSONArray("posts");
-            ArrayList<Question> res = new ArrayList<Question>();
-            for (int i = 0; i < array.length(); i++) {
-                JSONObject post = array.getJSONObject(i);
-                res.add(new Question(post.getString("title"), post.getString("body"), null));
-            }
-            return res;
-        }catch(JSONException e){
-            //TODO: JSONまわりのエラー対応
-            Log.d("err",e.getMessage());
-            e.printStackTrace();
-            return null;
+        if (json.getString("status") != "OK") {
+            // TODO: エラー処理
         }
+        JSONArray array = json.getJSONArray("posts");
+        ArrayList<Question> res = new ArrayList<Question>();
+        for (int i = 0; i < array.length(); i++) {
+            JSONObject post = array.getJSONObject(i);
+            res.add(new Question(post.getString("title"), post.getString("body"), null));
+        }
+        return res;
     }
 
     private HttpResponse sendByGet(String path, Map<String, String> params)
@@ -146,15 +125,15 @@ public class HQTPProxyImpl implements HQTPProxy {
             try {
                 http_post.setEntity(new UrlEncodedFormEntity(form_params, "UTF-8"));
             } catch (UnsupportedEncodingException e) {
-                e.printStackTrace();    // I think here is unreachable...
+                e.printStackTrace(); // I think here is unreachable...
             }
         }
         return send(http_post);
     }
-    
+
     private HttpResponse send(HttpUriRequest request) throws ClientProtocolException, IOException
     {
-        //TODO: Timeoutの設定をすべき？
+        // TODO: Timeoutの設定をすべき？
         DefaultHttpClient client = new DefaultHttpClient();
         HttpResponse response = null;
         client.setCookieStore(cookie_store);
@@ -166,11 +145,11 @@ public class HQTPProxyImpl implements HQTPProxy {
         }
         return response;
     }
-    
+
     private static JSONObject toJSON(HttpEntity entity) throws ParseException, IOException, JSONException
     {
         String response = EntityUtils.toString(entity);
-        entity.consumeContent();    //ここでconsumeするのはキモいのだろうか・・・
+        entity.consumeContent(); // ここでconsumeするのはキモいのだろうか・・・
         return new JSONObject(response);
     }
 }

--- a/client/test/org/hqtp/android/HQTPProxyImplTest.java
+++ b/client/test/org/hqtp/android/HQTPProxyImplTest.java
@@ -19,7 +19,8 @@ import com.xtremelabs.robolectric.Robolectric;
 @RunWith(HQTPProxyImplTestRunner.class)
 public class HQTPProxyImplTest {
 
-    @Inject HQTPProxy proxy;
+    @Inject
+    HQTPProxy proxy;
 
     @Before
     public void setUp() throws Exception {
@@ -54,15 +55,17 @@ public class HQTPProxyImplTest {
         HttpUriRequest sentHttpRequest = (HttpUriRequest) Robolectric.getSentHttpRequest(0);
         assertThat(sentHttpRequest.getURI(), equalTo(URI.create("http://www.hqtp.org/api/post/")));
         assertThat(sentHttpRequest.getMethod(), equalTo("POST"));
-        //TODO: パラメータについても検査したい
-        //Assert.assertTrue((EntityUtils.toString(((HttpPost)sentHttpRequest).getEntity())), false);
+        // TODO: パラメータについても検査したい
+        // Assert.assertTrue((EntityUtils.toString(((HttpPost)sentHttpRequest).getEntity())), false);
     }
 
     @Test
     public void getQuestionsShouldCallAPI() throws Exception {
         Robolectric.clearHttpResponseRules();
         Robolectric.clearPendingHttpResponses();
-        Robolectric.addPendingHttpResponse(200, "{\"status\":\"OK\",\"posts\":[{\"title\":\"title1\",\"body\":\"body1\"},{\"title\":\"title2\",\"body\":\"body2\"}]}");
+        Robolectric
+            .addPendingHttpResponse(200,
+                    "{\"status\":\"OK\",\"posts\":[{\"title\":\"title1\",\"body\":\"body1\"},{\"title\":\"title2\",\"body\":\"body2\"}]}");
 
         List<Question> res = proxy.getQuestions();
 
@@ -76,4 +79,30 @@ public class HQTPProxyImplTest {
         assertThat(res.get(1).getBody(), equalTo("body2"));
     }
 
+    @Test(expected = HQTPAPIException.class)
+    public void authenticateShouldThrowAPIException() throws Exception {
+        Robolectric.clearHttpResponseRules();
+        Robolectric.clearPendingHttpResponses();
+        Robolectric.addPendingHttpResponse(403, "{ \"status\": \"Forbidden\" }");
+
+        proxy.authenticate("DUMMY_ACCESS_TOKEN_KEY", "DUMMY_ACCESS_TOKEN_SECRET");
+    }
+
+    @Test(expected = HQTPAPIException.class)
+    public void postQuestionShouldThrowAPIException() throws Exception {
+        Robolectric.clearHttpResponseRules();
+        Robolectric.clearPendingHttpResponses();
+        Robolectric.addPendingHttpResponse(403, "{ \"status\": \"Forbidden\" }");
+
+        proxy.postQuestion("test title", "test body");
+    }
+
+    @Test(expected = HQTPAPIException.class)
+    public void getQuestionsShouldThrowAPIException() throws Exception {
+        Robolectric.clearHttpResponseRules();
+        Robolectric.clearPendingHttpResponses();
+        Robolectric.addPendingHttpResponse(403, "{ \"status\": \"Forbidden\" }");
+
+        proxy.getQuestions();
+    }
 }


### PR DESCRIPTION
今までHQTPProxyが握りつぶしていた例外を投げるようにした。
また、HQTPProxyが投げたAPIが成功しなかった場合に独自に例外を投げるようにした。
