### PR TITLE
メイン画面の認証ボタンを削除

### DIFF
--- a/client/res/layout/main.xml
+++ b/client/res/layout/main.xml
@@ -3,12 +3,6 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical" >
-
-    <Button
-        android:id="@+id/authentication_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/verification" />
 
     <Button
         android:id="@+id/getallpost_button"

--- a/client/src/org/hqtp/android/HQTPActivity.java
+++ b/client/src/org/hqtp/android/HQTPActivity.java
@@ -17,7 +17,6 @@ import com.google.inject.Inject;
 
 public class HQTPActivity extends RoboActivity implements OnClickListener {
 
-    @InjectView(R.id.authentication_button) Button authentication_button;
     @InjectView(R.id.getallpost_button)     Button getallpost_button;
     @InjectView(R.id.post_button)           Button post_button;
     @Inject HQTPProxy proxy;
@@ -27,7 +26,6 @@ public class HQTPActivity extends RoboActivity implements OnClickListener {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main);
 
-        authentication_button.setOnClickListener(this);
         getallpost_button.setOnClickListener(this);
         post_button.setOnClickListener(this);
     }
@@ -35,12 +33,6 @@ public class HQTPActivity extends RoboActivity implements OnClickListener {
     @Override
     public void onClick(View v) {
         switch (v.getId()) {
-        case R.id.authentication_button:
-            showAlert("authentication", "authentication_button is clicked");
-            // TODO: アクセストークンを取得
-            // TODO: proxy.authenticate(access_token_key,access_token_secret);
-            // TODO: 戻り値に応じてダイアログ表示
-            break;
         case R.id.getallpost_button:
             startActivity(new Intent(this, ListQuestionActivity.class));
             break;

--- a/client/test/org/hqtp/android/HQTPActivityTest.java
+++ b/client/test/org/hqtp/android/HQTPActivityTest.java
@@ -19,18 +19,18 @@ import com.xtremelabs.robolectric.shadows.ShadowIntent;
 @RunWith(HQTPActivityTestRunner.class)
 public class HQTPActivityTest {
 
-    @Inject HQTPActivity activity;
-    @Inject HQTPProxy proxy;
-    @InjectView(R.id.getallpost_button) Button getallpost_button;
-    @InjectView(R.id.post_button) Button post_button;
+    @Inject
+    HQTPActivity activity;
+    @Inject
+    HQTPProxy proxy;
+    @InjectView(R.id.getallpost_button)
+    Button getallpost_button;
+    @InjectView(R.id.post_button)
+    Button post_button;
 
     @Before
     public void setUp() throws Exception {
         activity.onCreate(null);
-    }
-
-    @Test
-    public void pressingTheButtonShouldAccessGetQuestion() throws Exception {
     }
 
     @Test


### PR DESCRIPTION
メイン画面の認証ボタンはもう不要なので削除しました。
関連するイベントハンドリングの処理やテストコードも削除しました。
