### PR TITLE
質問を投稿した時の戻り値の変更

### DIFF
--- a/server/mysite/question/tests.py
+++ b/server/mysite/question/tests.py
@@ -114,6 +114,21 @@ def test_about_post():
     >>> jobj['status'] == 'OK'
     True
 
+    # 戻り値の検証
+    >>> post = jobj['post']
+    >>> post['title'] == 'after auth'
+    True
+    >>> post['body'] == 'can post'
+    True
+    >>> 'user' in post
+    True
+    >>> 'id' in post['user']
+    True
+    >>> 'name' in post['user']
+    True
+    >>> 'time' in post
+    True
+
     # getで確かめてみると、確かに投稿が反映されています。
     >>> jobj = access_get_view(c)
     >>> jobj['status'] == 'OK'

--- a/server/mysite/question/views.py
+++ b/server/mysite/question/views.py
@@ -130,8 +130,8 @@ def post_view(request):
 
     added_by = request.user
     if added_by.is_authenticated():
-        Question.objects.create(title=title, body=body, added_by=added_by)
-        return json_response()
+        q = Question.objects.create(title=title, body=body, added_by=added_by)
+        return json_response(context=dict(post=q.to_dict()))
     else:
         return json_response_forbidden()
 


### PR DESCRIPTION
ステータスのみを返していたところ、質問のデータ(ID含む)も返すように変更
テストケースもそれに伴い変更
