### PR TITLE
#91 に関する修正

### DIFF
--- a/server/mysite/question/twutil/tw_util.py
+++ b/server/mysite/question/twutil/tw_util.py
@@ -31,7 +31,7 @@ def _get_vc(user_key, user_secret):
     """
     api = make_api(user_key, user_secret)
     vc = api.verify_credentials()
-    if vc is False:
+    if not vc:
         # 正しいアクセストークンキー、シークレットでなかった場合
         return {}
     ret = dict(id=vc.id, screen_name=vc.screen_name, name=vc.name)

--- a/server/mysite/question/twutil/tw_util.py
+++ b/server/mysite/question/twutil/tw_util.py
@@ -19,11 +19,11 @@ def _get_vc(user_key, user_secret):
     """
     >>> import consumer_info as ci
     >>> vc=_get_vc(ci.spa_key,ci.spa_secret)
-    >>> vc['id']==580619600
+    >>> vc['id'] == ci.spa_id
     True
-    >>> vc['screen_name']==u'android_spa'
+    >>> vc['screen_name'] == ci.spa_screen_name
     True
-    >>> vc['name']==u'android_spa'
+    >>> vc['name'] == ci.spa_name
     True
     >>> vc=_get_vc('dummy key','dummy secret')
     >>> vc=={}
@@ -38,12 +38,9 @@ def _get_vc(user_key, user_secret):
     return ret
 
 
-def get_vc(user_key, user_secret):
+def get_vc_mock(user_key, user_secret):
     """
     Tweepy mock-up
-
-    if MOCK in /mysite/settings.py == True
-    then use mock-up, else use _get_vc()
 
     If you want to use more twitter users,
     please add user into twitter_database.
@@ -52,16 +49,16 @@ def get_vc(user_key, user_secret):
     1. If input key is in the database, and secret is correct
        then return user information
 
-    >>> from consumer_info import (spa_key, spa_secret, spa_id,
-    ...                            spa_screen_name, spa_name)
-    >>> vc = get_vc(spa_key, spa_secret)
-    >>> vc == dict(id=spa_id, screen_name=spa_screen_name, name=spa_name)
+    >>> import consumer_info as ci
+    >>> vc = get_vc(ci.spa_key, ci.spa_secret)
+    >>> vc == dict(id=ci.spa_id, screen_name=ci.spa_screen_name,
+    ...            name=ci.spa_name)
     True
 
     2. If input key is in the database, but secret is wrong
        then return empty dictionary (and server return not found)
 
-    >>> vc = get_vc(spa_key, 'egg')
+    >>> vc = get_vc(ci.spa_key, 'egg')
     >>> vc == {}
     True
 
@@ -72,18 +69,14 @@ def get_vc(user_key, user_secret):
     Traceback (most recent call last):
         ...
     TypeError: character mapping must return integer, None or unicode
-    """
-    from mysite.settings import MOCK
-    if not MOCK:
-        return _get_vc(user_key, user_secret)
 
-    from consumer_info import (spa_key, spa_secret, spa_id,
-                               spa_screen_name, spa_name)
+    """
+    import consumer_info as ci
     twitter_database = {
-        spa_key: dict(secret=spa_secret,
-                      vc=dict(id=spa_id,
-                              screen_name=spa_screen_name,
-                              name=spa_name)
+        ci.spa_key: dict(secret=ci.spa_secret,
+                      vc=dict(id=ci.spa_id,
+                              screen_name=ci.spa_screen_name,
+                              name=ci.spa_name)
                       )
         }
     not_found_keys = set(['dummy key'])
@@ -99,6 +92,23 @@ def get_vc(user_key, user_secret):
     else:
         raise TypeError(('character mapping must return integer, '
                          'None or unicode'))
+
+
+def get_vc(user_key, user_secret):
+    u"""
+    "Regardless of the value of the DEBUG setting in mysite/settings.py,
+     all Django tests run with DEBUG=False."
+
+    Djangoの公式ドキュメントに書いてあるこの条件を利用して、
+    DEBUGの値がFalseならtestの実行中と判断し、
+    DEBUGの値がTrueならrunserverまたはshellの実行中と判定している
+    mysite/settings.pyのDEBUGの値はFalseにしないでください
+    """
+    from django.conf.global_settings import DEBUG
+    if DEBUG:
+        return _get_vc(user_key, user_secret)
+    else:
+        return get_vc_mock(user_key, user_secret)
 
 
 def _test():

--- a/server/mysite/question/views.py
+++ b/server/mysite/question/views.py
@@ -63,6 +63,7 @@ def auth_view(request):
         return json_response_bad_request()
 
     try:
+        # get twitter account by key and secret
         vc = get_vc(key, secret)
     except TypeError:
         # Error reason is not well known
@@ -70,6 +71,7 @@ def auth_view(request):
         return json_response_server_error()
 
     if vc == {}:
+        # 正しいアクセストークンキー、シークレットでなかった場合 など
         return json_response_not_found()
     user_name = vc['id']
 
@@ -77,11 +79,13 @@ def auth_view(request):
     # どちらもパスワードとしてtemp_passwordを設定する
     temp_password = User.objects.make_random_password()
     try:
+        # HQTP user exists
         user = User.objects.get(username=user_name)
         user.set_password(temp_password)
         user.save()
         created = False
     except User.DoesNotExist:
+        # User has twitter account, but doesn't have HQTP account
         # create new user
         user = User.objects.create_user(user_name, '', temp_password)
         profile = user.get_profile()

--- a/server/mysite/question/views.py
+++ b/server/mysite/question/views.py
@@ -73,37 +73,38 @@ def auth_view(request):
         return json_response_not_found()
     user_name = vc['id']
 
-    auth_user = authenticate(username=user_name, password=secret)
+    # 新規に作成されたユーザーも、登録済みだったユーザーも
+    # どちらもパスワードとしてtemp_passwordを設定する
+    temp_password = User.objects.make_random_password()
+    try:
+        user = User.objects.get(username=user_name)
+        user.set_password(temp_password)
+        user.save()
+        created = False
+    except User.DoesNotExist:
+        # create new user
+        user = User.objects.create_user(user_name, '', temp_password)
+        profile = user.get_profile()
+        profile.screen_name = vc['screen_name']
+        profile.name = vc['name']
+        profile.save()
+        created = True
+
+    auth_user = authenticate(username=user_name, password=temp_password)
+    # セキュリティのために、パスワード認証ができないようにします
+    # アクセストークンKEY、SECRETによる認証しか行いません
+    auth_user.set_unusable_password()
     if auth_user is not None:
         if auth_user.is_active:
             # Log in successful
-            created = False
             login(request, auth_user)
             user_info = user_to_dict(auth_user)
         else:
             # User is deleted
             return json_response_not_found()
     else:
-        # Log in failed
-        try:
-            # Password is incorrect
-            User.objects.get(username=user_name)
-            return json_response_forbidden()
-        except User.DoesNotExist:
-            # User not found
-            # create a new user and new user profile in database
-            new_user = User.objects.create_user(user_name, '', secret)
-
-            # set profile twitter screen_name and name
-            profile = new_user.get_profile()
-            profile.screen_name = vc['screen_name']
-            profile.name = vc['name']
-            profile.save()
-
-            created = True
-            new_user = authenticate(username=user_name, password=secret)
-            login(request, new_user)
-            user_info = user_to_dict(new_user)
+        # 新規作成・パスワードの設定を行っているのでここにはこないはず
+        return json_response_server_error()
 
     context = dict(created=created, user=user_info)
     return json_response(context)

--- a/server/mysite/settings.py
+++ b/server/mysite/settings.py
@@ -1,6 +1,7 @@
 # Django settings for mysite project.
 import os
 
+MOCK = True
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 

--- a/server/mysite/settings.py
+++ b/server/mysite/settings.py
@@ -1,7 +1,6 @@
 # Django settings for mysite project.
 import os
 
-MOCK = True
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 


### PR DESCRIPTION
今までは、Twitterのアクセストークンシークレットをパスワードに設定していた
それではアクセストークンが変化した時に再認証ができなくなってしまった。

そこで、
1. ランダムパスワードを設定
2. そのランダムパスワードを使って認証＆ログイン
3. パスワード認証を禁止に設定
という形式に変更しました。
