### PR TITLE
bugfix:switch test/runserver

### DIFF
--- a/server/mysite/question/twutil/tw_util.py
+++ b/server/mysite/question/twutil/tw_util.py
@@ -104,8 +104,8 @@ def get_vc(user_key, user_secret):
     DEBUGの値がTrueならrunserverまたはshellの実行中と判定している
     mysite/settings.pyのDEBUGの値はFalseにしないでください
     """
-    from django.conf.global_settings import DEBUG
-    if DEBUG:
+    from django.conf import settings
+    if settings.DEBUG:
         return _get_vc(user_key, user_secret)
     else:
         return get_vc_mock(user_key, user_secret)


### PR DESCRIPTION
#127 に関する修正

http://djangoproject.jp/doc/ja/1.0/topics/settings.html#python
を見てびっくり、やっちゃダメってコード書いてたorz

今までのだと、testはもちろん、runserver（実際の実行）でもFalse
となっていて、実際の実行でもモックが動いてしまっていた。
