### PR TITLE
#169 画像投稿に関する実装

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -45,6 +45,7 @@ nosetests.xml
 
 
 media/twicon/*
+media/uploads/*
 
 # test coverage output dir
 .cover

--- a/server/media/uploads/placeholder
+++ b/server/media/uploads/placeholder
@@ -1,0 +1,1 @@
+save upload file in this directory.

--- a/server/mysite/question/models.py
+++ b/server/mysite/question/models.py
@@ -26,19 +26,19 @@ class Post(models.Model):
 
     # 64bit(from -9223372036854775808 to 9223372036854775807)
     virtual_ts = models.BigIntegerField()
-    img_url = models.CharField(max_length=255)
+    image_url = models.CharField(max_length=255)
 
 
     def __unicode__(self):
         return self.body
 
     def to_dict(self):
-        # bodyもimg_urlもどちらも''なら、bodyが''の投稿
-        if self.img_url == '':
-            img_url = None
+        # bodyもimage_urlもどちらも''なら、bodyが''の投稿
+        if self.image_url == '':
+            image_url = None
             body = self.body
         else:
-            img_url = self.img_url
+            image_url = self.image_url
             body = None
 
         return dict(id=self.pk,
@@ -47,7 +47,7 @@ class Post(models.Model):
                     time=self.posted_at.isoformat(),
                     lecture=self.lecture.to_dict(),
                     virtual_ts=self.virtual_ts,
-                    img=img_url)
+                    image=image_url)
 
     @classmethod
     def time_to_vts(cls, t):

--- a/server/mysite/question/models.py
+++ b/server/mysite/question/models.py
@@ -26,17 +26,28 @@ class Post(models.Model):
 
     # 64bit(from -9223372036854775808 to 9223372036854775807)
     virtual_ts = models.BigIntegerField()
+    img_url = models.CharField(max_length=255)
+
 
     def __unicode__(self):
         return self.body
 
     def to_dict(self):
+        # bodyもimg_urlもどちらも''なら、bodyが''の投稿
+        if self.img_url == '':
+            img_url = None
+            body = self.body
+        else:
+            img_url = self.img_url
+            body = None
+
         return dict(id=self.pk,
-                    body=self.body,
+                    body=body,
                     user=user_to_dict(self.added_by),
                     time=self.posted_at.isoformat(),
                     lecture=self.lecture.to_dict(),
-                    virtual_ts=self.virtual_ts)
+                    virtual_ts=self.virtual_ts,
+                    img=img_url)
 
     @classmethod
     def time_to_vts(cls, t):

--- a/server/mysite/question/models.py
+++ b/server/mysite/question/models.py
@@ -47,7 +47,7 @@ class Post(models.Model):
                     time=self.posted_at.isoformat(),
                     lecture=self.lecture.to_dict(),
                     virtual_ts=self.virtual_ts,
-                    image=image_url)
+                    image_url=image_url)
 
     @classmethod
     def time_to_vts(cls, t):

--- a/server/mysite/question/shortcuts.py
+++ b/server/mysite/question/shortcuts.py
@@ -48,13 +48,18 @@ def access_timeline_get_view(client, lecture_id):
     return json.loads(response.content)
 
 
-def access_timeline_post_view(client, lecture_id, body,
-                              before_virtual_ts=None, after_virtual_ts=None):
+def access_timeline_post_view(client, lecture_id, body=None,
+                              before_virtual_ts=None, after_virtual_ts=None,
+                              image=None):
     url = '/api/lecture/timeline/'
-    dic = dict(id=lecture_id, body=body)
+    dic = dict(id=lecture_id)
+    if body is not None:
+        dic['body'] = body
     if before_virtual_ts is not None:
         dic['before_virtual_ts'] = before_virtual_ts
     if after_virtual_ts is not None:
         dic['after_virtual_ts'] = after_virtual_ts
+    if image is not None:
+        dic['image'] = image
     response = client.post(url, dic)
     return json.loads(response.content)

--- a/server/mysite/question/views.py
+++ b/server/mysite/question/views.py
@@ -233,7 +233,7 @@ def lecture_timeline_view(request):
             filename = 'img_' + str(post.pk)
             relative_pathname = os.path.join('uploads', filename)
             absolute_pathname = build_media_absolute_pathname(relative_pathname)
-            save_bindata(absolute_pathname, image['content'])
+            save_bindata(absolute_pathname, image.read())
             image_url = build_media_absolute_url(request, relative_pathname)
             post.image_url = image_url
             post.save()

--- a/server/mysite/question/views.py
+++ b/server/mysite/question/views.py
@@ -233,7 +233,7 @@ def lecture_timeline_view(request):
             filename = 'img_' + str(post.pk)
             relative_pathname = os.path.join('uploads', filename)
             absolute_pathname = build_media_absolute_pathname(relative_pathname)
-            save_bindata(absoluet_pathname, image['content'])
+            save_bindata(absolute_pathname, image['content'])
             image_url = build_media_absolute_url(request, relative_pathname)
             post.image_url = image_url
             post.save()

--- a/server/mysite/question/views.py
+++ b/server/mysite/question/views.py
@@ -192,8 +192,8 @@ def lecture_timeline_view(request):
             return json_response_bad_request()
 
         if (('body' in request.POST)
-            == ('img' in request.FILES)):
-            # bodyとimgのどちらか一方を指定
+            == ('image' in request.FILES)):
+            # bodyとimageのどちらか一方を指定
             return json_response_bad_request()
 
         if (('before_virtual_ts' in request.POST)
@@ -229,16 +229,16 @@ def lecture_timeline_view(request):
                                    added_by=request.user,
                                    virtual_ts=vts)
 
-        if 'img' in request.FILES:
-            img = request.FILES['img']
+        if 'image' in request.FILES:
             # save image file
             # ユニークなfilenameとして、Postのpkを使う
+            image = request.FILES['image']
             filename = 'img_' + str(post.pk)
             relative_pathname = os.path.join('uploads', filename)
             absolute_pathname = build_media_absolute_pathname(relative_pathname)
-            save_bindata(absoluet_pathname, img['content'])
-            img_url = build_media_absolute_url(request, relative_pathname)
-            post.img_url = img_url
+            save_bindata(absoluet_pathname, image['content'])
+            image_url = build_media_absolute_url(request, relative_pathname)
+            post.image_url = image_url
             post.save()
 
 


### PR DESCRIPTION
#169 実装してから時間がたってるのでMasterと比較するという意味で一旦PullRequest立てます。
1. Postモデルにimage_url フィールドを追加
2. POST /api/lecture/timelineにてbodyが必須から、bodyとimageのどちらかを選択する形に変わった

投稿された画像はmedia/uploads/に保存
