### PR TITLE
Issue173 client (N秒ごとにタイムラインの差分取得をする)

### DIFF
--- a/client/src/org/hqtp/android/HQTPProxy.java
+++ b/client/src/org/hqtp/android/HQTPProxy.java
@@ -17,6 +17,9 @@ public interface HQTPProxy {
     public abstract List<Post> getTimeline(int lectureId) throws IOException, HQTPAPIException, JSONException,
             ParseException;
 
+    public abstract List<Post> getTimeline(int lectureId, int sinceId) throws IOException, HQTPAPIException, JSONException,
+            ParseException;
+
     /**
      * @param body 送信する投稿本文
      * @param lectureId 授業ID

--- a/client/src/org/hqtp/android/HQTPProxyImpl.java
+++ b/client/src/org/hqtp/android/HQTPProxyImpl.java
@@ -43,8 +43,15 @@ public class HQTPProxyImpl implements HQTPProxy {
     @Override
     public List<Post> getTimeline(int lectureId) throws IOException, HQTPAPIException, JSONException,
             java.text.ParseException {
+        return getTimeline(lectureId, 0);
+    }
+
+    @Override
+    public List<Post> getTimeline(int lectureId, int sinceId) throws IOException, HQTPAPIException, JSONException,
+            java.text.ParseException {
         String response = builder.get("lecture/timeline/")
             .param("id", lectureId)
+            .param("since_id", sinceId)
             .send();
         JSONObject json = new JSONObject(response);
         ArrayList<Post> posts = new ArrayList<Post>();

--- a/client/src/org/hqtp/android/Post.java
+++ b/client/src/org/hqtp/android/Post.java
@@ -9,7 +9,7 @@ import java.util.TimeZone;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-public class Post {
+public class Post implements Comparable<Post> {
     private final static int VIRTUAL_TS_SCALE = 100000;
 
     private int id;
@@ -76,5 +76,16 @@ public class Post {
 
     public static long dateToVirtualTimestamp(Date date) {
         return date.getTime() * VIRTUAL_TS_SCALE;
+    }
+
+    @Override
+    public int compareTo(Post another) {
+        if (this.virtualTimestamp < another.virtualTimestamp) {
+            return -1;
+        } else if (this.virtualTimestamp == another.virtualTimestamp) {
+            return 0;
+        } else {
+            return 1;
+        }
     }
 }

--- a/client/src/org/hqtp/android/TimelineAdapter.java
+++ b/client/src/org/hqtp/android/TimelineAdapter.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.SortedSet;
 import java.util.TimeZone;
 
 import roboguice.inject.ContextSingleton;
@@ -154,7 +155,7 @@ class TimelineAdapter extends BaseAdapter implements TimelineObserver {
     }
 
     @Override
-    public void onUpdate(List<Post> posts) {
+    public void onUpdate(SortedSet<Post> posts) {
         synchronized (cells) {
             boolean formCellAdded = false;
             long beforeFormCellId = Long.MAX_VALUE;

--- a/client/src/org/hqtp/android/TimelineObserver.java
+++ b/client/src/org/hqtp/android/TimelineObserver.java
@@ -1,7 +1,7 @@
 package org.hqtp.android;
 
-import java.util.List;
+import java.util.SortedSet;
 
 public interface TimelineObserver {
-    void onUpdate(List<Post> posts);
+    void onUpdate(SortedSet<Post> posts);
 }

--- a/client/src/org/hqtp/android/TimelineRecurringUpdaterImpl.java
+++ b/client/src/org/hqtp/android/TimelineRecurringUpdaterImpl.java
@@ -90,9 +90,12 @@ public class TimelineRecurringUpdaterImpl implements TimelineRecurringUpdater {
 
             @Override
             protected void onSuccess(List<Post> new_posts) throws Exception {
-                if (new_posts.size() != 0) {
+                // In this task manager, only one instance of this task is run.
+                // We don't need to lock posts member.
+                if (!new_posts.isEmpty()) {
                     posts.addAll(new_posts);
-                    since_id = posts.last().getId();
+                    // NOTE: since_id is the last retrieved post's id, not sorted posts' last item's id.
+                    since_id = new_posts.get(new_posts.size() - 1).getId();
 
                     if (!stopped.get()) {
                         for (TimelineObserver observer : observers) {

--- a/client/src/org/hqtp/android/TimelineRecurringUpdaterImpl.java
+++ b/client/src/org/hqtp/android/TimelineRecurringUpdaterImpl.java
@@ -3,6 +3,8 @@ package org.hqtp.android;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -67,6 +69,8 @@ public class TimelineRecurringUpdaterImpl implements TimelineRecurringUpdater {
         private ScheduledExecutorService wait_thread = Executors.newSingleThreadScheduledExecutor();
         private AtomicBoolean stopped = new AtomicBoolean(false);
         private RecurringTask task;
+        private SortedSet<Post> posts = new TreeSet<Post>();
+        private int since_id = 0;
 
         public void start() {
             task = new RecurringTask();
@@ -81,14 +85,19 @@ public class TimelineRecurringUpdaterImpl implements TimelineRecurringUpdater {
         private class RecurringTask extends SafeAsyncTask<List<Post>> {
             @Override
             public List<Post> call() throws Exception {
-                return proxy.getTimeline(lecture_id);
+                return proxy.getTimeline(lecture_id, since_id);
             }
 
             @Override
-            protected void onSuccess(List<Post> posts) throws Exception {
-                if (!stopped.get()) {
-                    for (TimelineObserver observer : observers) {
-                        observer.onUpdate(posts);
+            protected void onSuccess(List<Post> new_posts) throws Exception {
+                if (new_posts.size() != 0) {
+                    posts.addAll(new_posts);
+                    since_id = posts.last().getId();
+
+                    if (!stopped.get()) {
+                        for (TimelineObserver observer : observers) {
+                            observer.onUpdate(posts);
+                        }
                     }
                 }
             }

--- a/client/test/org/hqtp/android/TimelineAdapterTest.java
+++ b/client/test/org/hqtp/android/TimelineAdapterTest.java
@@ -1,10 +1,10 @@
 package org.hqtp.android;
 
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.hqtp.android.util.HQTPTestRunner;
 import org.hqtp.android.util.RoboGuiceTest;
@@ -48,7 +48,7 @@ public class TimelineAdapterTest extends RoboGuiceTest {
     private Post testOldPost;
     private User testUser;
     private Lecture testLecture;
-    private List<Post> testPosts;
+    private SortedSet<Post> testPosts;
 
     private static final int INITIAL_FORM = 1;
     private static final int NUM_INITIAL_CELLS = 2;
@@ -76,7 +76,7 @@ public class TimelineAdapterTest extends RoboGuiceTest {
         Date d = new Date(new Date().getTime() - 24 * 60 * 60 * 1000);
         testPost = new Post(3, "body", new Date(), Post.dateToVirtualTimestamp(d),
                 testUser, testLecture);
-        testPosts = new ArrayList<Post>();
+        testPosts = new TreeSet<Post>();
         testPosts.add(testOldPost);
         testPosts.add(testPost);
     }

--- a/client/test/org/hqtp/android/TimelineRecurringUpdaterTest.java
+++ b/client/test/org/hqtp/android/TimelineRecurringUpdaterTest.java
@@ -3,6 +3,8 @@ package org.hqtp.android;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.hqtp.android.util.HQTPTestRunner;
 import org.hqtp.android.util.RoboGuiceTest;
@@ -17,7 +19,7 @@ import com.google.inject.name.Names;
 
 import static org.junit.Assert.assertThat;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 import static org.mockito.Mockito.*;
 
@@ -30,23 +32,30 @@ public class TimelineRecurringUpdaterTest extends RoboGuiceTest {
     @Inject
     HQTPProxy proxy;
 
-    private Post testPost;
+    private Post testPost, testPost2;
     private User testUser;
     private Lecture testLecture;
-    private List<Post> testPosts;
+    private List<Post> testPosts, testPosts2;
+    private SortedSet<Post> sortedTestPosts, sortedTestPosts2;
 
     @Before
     public void setUpFixture() throws Exception {
         testUser = new User(1, "testUser", "http://example.com/icon.png");
         testLecture = new Lecture(2, "testLecture", "testLectureCode");
         testPost = new Post(3, "body", new Date(), 1000, testUser, testLecture);
+        testPost2 = new Post(4, "body", new Date(), 1000, testUser, testLecture);
         testPosts = new ArrayList<Post>();
         testPosts.add(testPost);
+        sortedTestPosts = new TreeSet<Post>(testPosts);
+        testPosts2 = new ArrayList<Post>();
+        testPosts2.add(testPost);
+        testPosts2.add(testPost2);
+        sortedTestPosts2 = new TreeSet<Post>(testPosts2);
     }
 
     @Test
     public void updaterShouldNotifyObserver() throws Exception {
-        when(proxy.getTimeline(LECTURE_ID)).thenReturn(testPosts);
+        when(proxy.getTimeline(LECTURE_ID, 0)).thenReturn(testPosts);
 
         TestObserver observer = new TestObserver();
 
@@ -56,15 +65,15 @@ public class TimelineRecurringUpdaterTest extends RoboGuiceTest {
         Thread.sleep(100);
 
         updater.stop();
-        verify(proxy).getTimeline(LECTURE_ID);
+        verify(proxy).getTimeline(LECTURE_ID, 0);
         assertThat(observer.times, equalTo(1));
-        assertThat(observer.posts, equalTo(testPosts));
+        assertThat(observer.posts, equalTo(sortedTestPosts));
     }
 
     @Test
     public void updaterShouldNotifyRecurrently() throws Exception {
-        when(proxy.getTimeline(LECTURE_ID))
-            .thenReturn(testPosts).thenReturn(testPosts);
+        when(proxy.getTimeline(LECTURE_ID, 0)).thenReturn(testPosts);
+        when(proxy.getTimeline(LECTURE_ID, testPost.getId())).thenReturn(testPosts2);
 
         TestObserver observer = new TestObserver();
 
@@ -74,12 +83,34 @@ public class TimelineRecurringUpdaterTest extends RoboGuiceTest {
         Thread.sleep(1000);
 
         updater.stop();
-        assertThat(observer.times > 1, is(true));
+        assertThat(observer.times, equalTo(2));
+        assertThat(observer.posts, equalTo(sortedTestPosts2));
+        verify(proxy).getTimeline(LECTURE_ID, 0);
+        verify(proxy).getTimeline(LECTURE_ID, testPost.getId());
+    }
+
+    @Test
+    public void updaterShouldNotNotifyIfNoPosts() throws Exception {
+        when(proxy.getTimeline(LECTURE_ID, 0)).thenReturn(testPosts);
+        when(proxy.getTimeline(LECTURE_ID, testPost.getId())).thenReturn(new ArrayList<Post>());
+
+        TestObserver observer = new TestObserver();
+
+        updater.setLectureId(LECTURE_ID);
+        updater.registerTimelineObserver(observer);
+        updater.startRecurringUpdateTimeline();
+        Thread.sleep(1000);
+
+        updater.stop();
+        assertThat(observer.times, equalTo(1));
+        assertThat(observer.posts, equalTo(sortedTestPosts));
+        verify(proxy).getTimeline(LECTURE_ID, 0);
+        verify(proxy).getTimeline(LECTURE_ID, testPost.getId());
     }
 
     @Test
     public void unregisteredObserverShouldNotNotified() throws Exception {
-        when(proxy.getTimeline(LECTURE_ID)).thenReturn(testPosts);
+        when(proxy.getTimeline(LECTURE_ID, 0)).thenReturn(testPosts);
 
         TestObserver observer = new TestObserver();
 
@@ -91,12 +122,12 @@ public class TimelineRecurringUpdaterTest extends RoboGuiceTest {
         updater.unregisterTimelineObserver(observer);
         Thread.sleep(1000);
         assertThat(observer.times, equalTo(1));
-        assertThat(observer.posts, equalTo(testPosts));
+        assertThat(observer.posts, equalTo(sortedTestPosts));
     }
 
     @Test
     public void shouldNotNotifyAfterStopped() throws Exception {
-        when(proxy.getTimeline(LECTURE_ID)).thenReturn(testPosts);
+        when(proxy.getTimeline(LECTURE_ID, 0)).thenReturn(testPosts);
 
         TestObserver observer = new TestObserver();
 
@@ -105,24 +136,24 @@ public class TimelineRecurringUpdaterTest extends RoboGuiceTest {
         updater.startRecurringUpdateTimeline();
         Thread.sleep(100);
         assertThat(observer.times, equalTo(1));
-        assertThat(observer.posts, equalTo(testPosts));
+        assertThat(observer.posts, equalTo(sortedTestPosts));
 
         updater.stop();
         Thread.sleep(1000);
         assertThat(observer.times, equalTo(1));
-        assertThat(observer.posts, equalTo(testPosts));
+        assertThat(observer.posts, equalTo(sortedTestPosts));
     }
 
     @Test
     public void updaterShouldCallProxy() throws Exception {
-        when(proxy.getTimeline(LECTURE_ID)).thenReturn(testPosts);
+        when(proxy.getTimeline(LECTURE_ID, 0)).thenReturn(testPosts);
 
         updater.setLectureId(LECTURE_ID);
         updater.startRecurringUpdateTimeline();
         Thread.sleep(100);
 
         updater.stop();
-        verify(proxy).getTimeline(LECTURE_ID);
+        verify(proxy).getTimeline(LECTURE_ID, 0);
     }
 
     @Test
@@ -134,11 +165,11 @@ public class TimelineRecurringUpdaterTest extends RoboGuiceTest {
     }
 
     private class TestObserver implements TimelineObserver {
-        public List<Post> posts = null;
+        public SortedSet<Post> posts = null;
         public int times = 0;
 
         @Override
-        public void onUpdate(List<Post> posts) {
+        public void onUpdate(SortedSet<Post> posts) {
             this.posts = posts;
             times++;
         }


### PR DESCRIPTION
差分修得が出来るようにAPIを変更して、それに対応するようにアップデート部分を書き直しました。

基本的にHQTPProxyは変わらなくて、TimelineRecurringUpdaterが内部でソートを行なって、それをObserverに返すという形です。ソートされている状態を保つために毎回ソートを行なっても良いのですが、効率が悪いのでTreeSet(SortedSet)にしています。

Author: @draftcode
Reviewer: @ide-an
Issue: #173 #203 #200
