### PR TITLE
#241 Bug fix

### DIFF
--- a/server/mysite/question/test_unit.py
+++ b/server/mysite/question/test_unit.py
@@ -353,6 +353,13 @@ class AchievementTests(TestCase):
         j_after = self.get_achevements_from_db()[0]
         self.assertEqual(j_after['point'], 30)
 
+    def test_achievement_add_lecture_not_created(self):
+        # 既存の授業を追加しても実績は追加されない
+        sc.access_lecture_add_view(self.client, name='Software Test',
+                                   code='76036')  # existing code
+        achievement_list = self.get_achevements_from_db()
+        self.assertListEqual(achievement_list, [])
+
     def test_achievement_one_post(self):
         sc.access_timeline_post_view(self.client, lecture_id=1, body='Hello')
         j_after = self.get_achevements_from_db()[0]

--- a/server/mysite/question/views.py
+++ b/server/mysite/question/views.py
@@ -159,7 +159,8 @@ def lecture_add_view(request):
     # get_or_create(): 新規作成したらcreated = True
     lec, created = Lecture.objects.get_or_create(
         code=code, defaults=dict(name=name))
-    give_achievement('add_lecture', request.user)
+    if created:
+        give_achievement('add_lecture', request.user)
     return json_response(context=dict(created=created, lecture=lec.to_dict()))
 
 

--- a/server/mysite/test_shell_auth.sh
+++ b/server/mysite/test_shell_auth.sh
@@ -7,6 +7,9 @@ expect ">>>"
 send "from django.test.client import Client\n"
 
 expect ">>>"
+send "import mysite.question.shortcuts as sc\n"
+
+expect ">>>"
 send "c = Client()\n"
 
 expect ">>>"


### PR DESCRIPTION
#241 に関して

・ `created=False` の場合でも実績が追加されていたバグを修正
・それに関するテスト
