### PR TITLE
Issue178 client (Add a button to clear login information.)

### DIFF
--- a/client/res/layout/login.xml
+++ b/client/res/layout/login.xml
@@ -27,7 +27,6 @@
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true" >
 
         <EditText
@@ -47,5 +46,12 @@
             android:layout_height="wrap_content"
             android:text="change endpoint" />
     </LinearLayout>
+
+    <Button
+        android:id="@+id/clearLoginInfoButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:text="ログイン情報を消去" />
 
 </RelativeLayout>

--- a/client/src/org/hqtp/android/LoginActivity.java
+++ b/client/src/org/hqtp/android/LoginActivity.java
@@ -30,6 +30,8 @@ public class LoginActivity extends RoboActivity implements OnClickListener {
     Button changeEndpointButton;
     @InjectView(R.id.endpointText)
     TextView endpointText;
+    @InjectView(R.id.clearLoginInfoButton)
+    Button clearLoginInfoButton;
 
     private final String callback_url = "hqtp://request_callback/";
     private RequestToken requestToken;
@@ -49,6 +51,7 @@ public class LoginActivity extends RoboActivity implements OnClickListener {
         setContentView(R.layout.login);
         loginButton.setOnClickListener(this);
         changeEndpointButton.setOnClickListener(this);
+        clearLoginInfoButton.setOnClickListener(this);
 
         preferences = getPreferences(MODE_PRIVATE);
 
@@ -75,6 +78,11 @@ public class LoginActivity extends RoboActivity implements OnClickListener {
             if (!new_endpoint.isEmpty()) {
                 ((APIClientImpl) proxy).setEndpoint(new_endpoint);
             }
+        } else if (v.getId() == R.id.clearLoginInfoButton) {
+            Editor e = preferences.edit();
+            e.putBoolean(SAVED_AUTH_TOKEN_STATE, false);
+            e.commit();
+            alerter.alert("HQTP", "ログイン情報を消去しました");
         }
     }
 

--- a/client/src/org/hqtp/android/LoginActivity.java
+++ b/client/src/org/hqtp/android/LoginActivity.java
@@ -80,7 +80,9 @@ public class LoginActivity extends RoboActivity implements OnClickListener {
             }
         } else if (v.getId() == R.id.clearLoginInfoButton) {
             Editor e = preferences.edit();
-            e.putBoolean(SAVED_AUTH_TOKEN_STATE, false);
+            e.remove(SAVED_AUTH_TOKEN_STATE);
+            e.remove(SAVED_AUTH_TOKEN);
+            e.remove(SAVED_AUTH_TOKEN_SECRET);
             e.commit();
             alerter.alert("HQTP", "ログイン情報を消去しました");
         }


### PR DESCRIPTION
ログイン情報を消去するボタンをログイン画面に追加しました。

Author: @draftcode
Reviewer: @ide-an 
Issue: #178
