### PR TITLE
Issue254 client (Fix an issue that the time is wrongly manipulated.)

### DIFF
--- a/client/src/org/hqtp/android/TimelineAdapter.java
+++ b/client/src/org/hqtp/android/TimelineAdapter.java
@@ -281,7 +281,7 @@ class TimelineAdapter extends BaseAdapter implements TimelineObserver {
                     // Make sure to make a post not to beyond a day.
                     Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("Asia/Tokyo"));
                     cal.setTime(Post.virtualTimestampToDate(prevVirtualTimestamp));
-                    cal.set(Calendar.HOUR, 23);
+                    cal.set(Calendar.HOUR_OF_DAY, 23);
                     cal.set(Calendar.MINUTE, 59);
                     cal.set(Calendar.SECOND, 59);
                     cal.set(Calendar.MILLISECOND, 999);
@@ -386,7 +386,7 @@ class TimelineAdapter extends BaseAdapter implements TimelineObserver {
         public DateSeparatorCell(Date date) {
             Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("Asia/Tokyo"));
             cal.setTime(date);
-            cal.set(Calendar.HOUR, 0);
+            cal.set(Calendar.HOUR_OF_DAY, 0);
             cal.set(Calendar.MINUTE, 0);
             cal.set(Calendar.SECOND, 0);
             cal.set(Calendar.MILLISECOND, 0);

--- a/client/test/org/hqtp/android/TimelineAdapterTest.java
+++ b/client/test/org/hqtp/android/TimelineAdapterTest.java
@@ -231,7 +231,7 @@ public class TimelineAdapterTest extends RoboGuiceTest {
         // The date separator's virtual timestamp is calculated based on the following post.
         Calendar cal = Calendar.getInstance();
         cal.setTime(Post.virtualTimestampToDate(testPost.getVirtualTimestamp()));
-        cal.set(Calendar.HOUR, 0);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
         cal.set(Calendar.MILLISECOND, 0);
@@ -320,7 +320,7 @@ public class TimelineAdapterTest extends RoboGuiceTest {
         ShadowIntent shadowIntent = shadowOf(startedIntent);
         Calendar cal = Calendar.getInstance();
         cal.setTime(Post.virtualTimestampToDate(testPost.getVirtualTimestamp()));
-        cal.set(Calendar.HOUR, 0);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
         cal.set(Calendar.MILLISECOND, 0);
@@ -349,7 +349,7 @@ public class TimelineAdapterTest extends RoboGuiceTest {
         ShadowIntent shadowIntent = shadowOf(startedIntent);
         Calendar cal = Calendar.getInstance();
         cal.setTime(Post.virtualTimestampToDate(testOldPost.getVirtualTimestamp()));
-        cal.set(Calendar.HOUR, 23);
+        cal.set(Calendar.HOUR_OF_DAY, 23);
         cal.set(Calendar.MINUTE, 59);
         cal.set(Calendar.SECOND, 59);
         cal.set(Calendar.MILLISECOND, 999);


### PR DESCRIPTION
時刻を設定するときに、12時間表記における時刻で設定していた問題を修正した。

Author: @draftcode
Reviewer: @ide-an 
Issue: #254
