### PR TITLE
Issue210 client(実績通知)

### DIFF
--- a/client/src/org/hqtp/android/Achievement.java
+++ b/client/src/org/hqtp/android/Achievement.java
@@ -4,6 +4,8 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.TimeZone;
 
 import org.json.JSONException;
@@ -50,5 +52,22 @@ public class Achievement {
                 json.getString("name"),
                 json.getInt("point"),
                 df.parse(json.getString("created_at")));
+    }
+
+    private static final Map<String, String> nameToDescription = new HashMap<String, String>();
+    static {
+        nameToDescription.put("first_login", "はじめてのろぐいん");
+        nameToDescription.put("add_lecture", "講義追加");
+        nameToDescription.put("one_post", "投稿");
+        nameToDescription.put("upload_image", "画像付き");
+        nameToDescription.put("upload_url", "URL付き");
+        nameToDescription.put("consecutive_post", "またお前か");
+        nameToDescription.put("easter_egg", "？？？？");
+        nameToDescription.put("post_inserted", "りぷらい");
+        nameToDescription.put("attend_lecture", "出席");
+    }
+
+    public static String getDescription(Achievement achievement) {
+        return nameToDescription.get(achievement.getName());
     }
 }

--- a/client/src/org/hqtp/android/ProfileView.java
+++ b/client/src/org/hqtp/android/ProfileView.java
@@ -35,6 +35,8 @@ public class ProfileView extends LinearLayout {
     Activity activity;
     @Inject
     APIClient proxy;
+    @Inject
+    Alerter alerter;
 
     public ProfileView(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -56,7 +58,7 @@ public class ProfileView extends LinearLayout {
     {
         if (user != null) {
             username_view.setText(user.getName());
-            updateTotalPoint(user.getTotalPoint());// TODO: show user's point
+            updateTotalPoint(user.getTotalPoint());
             icon_view.setTag(user.getIconURL());
             loader.displayImage(icon_view, this.activity);
         } else {
@@ -120,7 +122,9 @@ public class ProfileView extends LinearLayout {
             List<Achievement> achievements = achievement_response.getAchievements();
             int size = achievements.size();
             if (size > 0) {
-                // TODO: 実績通知
+                for (Achievement achieve : achievements) {
+                    alerter.toastShort(Achievement.getDescription(achieve) + "！ +" + achieve.getPoint() + "pt!");
+                }
                 since_id = achievements.get(size - 1).getId();
             }
         }

--- a/client/src/org/hqtp/android/TimelineAdapter.java
+++ b/client/src/org/hqtp/android/TimelineAdapter.java
@@ -151,7 +151,6 @@ class TimelineAdapter extends BaseAdapter implements TimelineObserver {
                 cells.add(formCell);
             }
             observable.notifyChanged();
-            alerter.toastShort("投稿しました");
         }
     }
 


### PR DESCRIPTION
実績通知の実装
- ProfileView内でポーリングして取得した実績をToastで通知する
- since_idを保存することでアクティビティ間でどの実績まで通知したかを共有

since_idの更新タイミングについては実績ポーリングで新たな実績を拾ったときに行なっている。

Author: @ide-an
Reviewer: @draftcode 
Issue: #210
