### PR TITLE
Issue269 client (Fix the definition of the identity of the posts.)

### DIFF
--- a/client/src/org/hqtp/android/Post.java
+++ b/client/src/org/hqtp/android/Post.java
@@ -10,6 +10,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 public class Post implements Comparable<Post> {
+
     private final static int VIRTUAL_TS_SCALE = 100000;
 
     private int id;
@@ -96,9 +97,19 @@ public class Post implements Comparable<Post> {
         if (this.virtualTimestamp < another.virtualTimestamp) {
             return -1;
         } else if (this.virtualTimestamp == another.virtualTimestamp) {
-            return 0;
+            return Integer.valueOf(this.id).compareTo(another.id);
         } else {
             return 1;
+        }
+    }
+
+    @Override
+    public boolean equals(Object another) {
+        if (another instanceof Post){
+            Post obj = (Post) another;
+            return obj.id == this.id;
+        } else {
+            return false;
         }
     }
 }

--- a/client/test/org/hqtp/android/TimelineRecurringUpdaterTest.java
+++ b/client/test/org/hqtp/android/TimelineRecurringUpdaterTest.java
@@ -85,6 +85,7 @@ public class TimelineRecurringUpdaterTest extends RoboGuiceTest {
         updater.stop();
         assertThat(observer.times, equalTo(2));
         assertThat(observer.posts, equalTo(sortedTestPosts2));
+        assertThat(observer.posts.size(), equalTo(2));
         verify(proxy).getTimeline(LECTURE_ID, 0);
         verify(proxy).getTimeline(LECTURE_ID, testPost.getId());
     }


### PR DESCRIPTION
投稿が同一であるかどうかの判定をきちんとIDまで見て判定するようにした。

Author: @draftcode
Reviewer: @ide-an 
Issue: #269
