### PR TITLE
Issue273-client(画像キャッシュの始末:bug修正)

### DIFF
--- a/client/src/org/hqtp/android/ProfileView.java
+++ b/client/src/org/hqtp/android/ProfileView.java
@@ -108,6 +108,7 @@ public class ProfileView extends LinearLayout {
             executor.shutdown();
         }
         loader.clearCache();
+        updateUserInfo(null);
     }
 
     private SharedPreferences getPreferences() {


### PR DESCRIPTION
以前投げてマージされたpull requestに関して以下のバグがあったので修正
- あるアクテビティから別のアクテビティに遷移→元のアクテビティに戻るとRuntimeExceptionで落ちる

Author: @ide-an
Issue:  #273
