### PR TITLE
Revert "Recycle bitmap before clear cache. Clear cache when ProfileView is stopping"

### DIFF
--- a/client/src/org/hqtp/android/ImageLoaderImpl.java
+++ b/client/src/org/hqtp/android/ImageLoaderImpl.java
@@ -2,7 +2,6 @@ package org.hqtp.android;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -51,9 +50,6 @@ public class ImageLoaderImpl implements ImageLoader {
     }
 
     public void clearCache() {
-        for (Entry<String, Bitmap> entry : image_cache.entrySet()) {
-            entry.getValue().recycle();
-        }
         image_cache.clear();
     }
 

--- a/client/src/org/hqtp/android/ProfileView.java
+++ b/client/src/org/hqtp/android/ProfileView.java
@@ -107,7 +107,6 @@ public class ProfileView extends LinearLayout {
             stopped.set(true);
             executor.shutdown();
         }
-        loader.clearCache();
     }
 
     private SharedPreferences getPreferences() {


### PR DESCRIPTION
#273 についての修正がもたらすバグが根深い感じだったのでリバートします。

問題点をまとめると
- ImageViewがまだ参照しているBitmapに対してrecycle()を呼んでしまう(これが例外を発生させる直接の原因)
- だが、ImageViewのbitmapへの参照をコントロールするのは(特にTimeline関連では)難しい
